### PR TITLE
Switch CoreUI utility imports to @coreui/utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@auth0/angular-jwt": "^5.0.2",
     "@coreui/angular": "^2.11.2",
     "@coreui/coreui": "^2.1.16",
+    "@coreui/utils": "^1.3.1",
     "@coreui/coreui-plugin-chartjs-custom-tooltips": "^1.3.1",
     "@coreui/icons": "^2.0.0-rc.0",
     "@coreui/icons-angular": "1.0.0-alpha.3",

--- a/src/app/views/dashboard/dashboard.component.ts
+++ b/src/app/views/dashboard/dashboard.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { getStyle, hexToRgba } from '@coreui/coreui/dist/js/coreui-utilities';
+import { getStyle, hexToRgba } from '@coreui/utils';
 import { CustomTooltips } from '@coreui/coreui-plugin-chartjs-custom-tooltips';
 
 @Component({

--- a/src/app/views/theme/colors.component.ts
+++ b/src/app/views/theme/colors.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
-import { getStyle, rgbToHex } from '@coreui/coreui/dist/js/coreui-utilities';
+import { getStyle, rgbToHex } from '@coreui/utils';
 
 @Component({
   templateUrl: 'colors.component.html'

--- a/src/app/views/widgets/widgets.component.ts
+++ b/src/app/views/widgets/widgets.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { getStyle } from '@coreui/coreui/dist/js/coreui-utilities';
+import { getStyle } from '@coreui/utils';
 import { CustomTooltips } from '@coreui/coreui-plugin-chartjs-custom-tooltips';
 
 @Component({


### PR DESCRIPTION
## Summary
- add the @coreui/utils dependency to package.json
- update CoreUI utility imports in dashboard, colors, and widgets components to use @coreui/utils

## Testing
- npm install *(fails: 403 Forbidden when reaching the npm registry from the container environment)*
- npx ng build *(fails: 403 Forbidden when reaching the npm registry from the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccfe3a99888326a9b0f8ada5ac4ed0