### PR TITLE
Handle missing transport types gracefully

### DIFF
--- a/src/app/views/parcare-modules/storage-prices/storage-prices.component.ts
+++ b/src/app/views/parcare-modules/storage-prices/storage-prices.component.ts
@@ -65,8 +65,9 @@ export class StoragePricesComponent implements OnInit {
 
   // transport type filter
   public getTransportNameByID(typeId) {
-    return this.transportTypes.filter(type => typeId === type.ID)[0].type;
-  } 
+    const matchedType = this.transportTypes.find(type => typeId === type.ID);
+    return matchedType ? matchedType.type : '';
+  }
 
   // function to add entity (showing the input)
   public async addEntity() {


### PR DESCRIPTION
## Summary
- replace the transport type lookup filter with Array.find
- return an empty string when a matching transport type is not found so the template renders safely

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccff29ac888326916a7910cc0e3059