### PR TITLE
Fix Excel report comment spelling

### DIFF
--- a/src/app/api/api.service.ts
+++ b/src/app/api/api.service.ts
@@ -87,7 +87,7 @@ export class ApiService {
   public excludeCarFn(id: any): Observable<any> {
     return this.httpClient.get(`${this.hostIP}/admin/car/${id}`)
   }
-// Excell Report ------------------------------------------------------------------------------------------------
+// Excel Report ------------------------------------------------------------------------------------------------
 public getCarReport(durationObj) {
   var reqHeader = new HttpHeaders({
     'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- correct the "Excel Report" section comment spelling in the API service

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ccffd12e9c83268ebea42ac56b8584