### PR TITLE
Add tests for storage price transport type lookup

### DIFF
--- a/src/app/views/parcare-modules/storage-prices/storage-prices.component.spec.ts
+++ b/src/app/views/parcare-modules/storage-prices/storage-prices.component.spec.ts
@@ -22,4 +22,25 @@ describe('StoragePricesComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should return transport type name for a known ID', () => {
+    component.transportTypes = [
+      { ID: 1, type: 'Autoturism' },
+      { ID: 2, type: 'Autobuz' }
+    ] as any;
+
+    const result = component.getTransportNameByID(2);
+
+    expect(result).toBe('Autobuz');
+  });
+
+  it('should return fallback for unknown transport type ID', () => {
+    component.transportTypes = [
+      { ID: 1, type: 'Autoturism' }
+    ] as any;
+
+    const result = component.getTransportNameByID(3);
+
+    expect(result).toBe('Tip necunoscut');
+  });
 });

--- a/src/app/views/parcare-modules/storage-prices/storage-prices.component.ts
+++ b/src/app/views/parcare-modules/storage-prices/storage-prices.component.ts
@@ -65,8 +65,9 @@ export class StoragePricesComponent implements OnInit {
 
   // transport type filter
   public getTransportNameByID(typeId) {
-    return this.transportTypes.filter(type => typeId === type.ID)[0].type;
-  } 
+    const transportType = this.transportTypes.find(type => typeId === type.ID);
+    return transportType ? transportType.type : 'Tip necunoscut';
+  }
 
   // Adds a storage price via API and refreshes the list/UI state
   public async addEntity() {


### PR DESCRIPTION
## Summary
- add unit tests that cover the transport type lookup and fallback logic in `StoragePricesComponent`
- update `getTransportNameByID` to safely return a fallback label when the transport type cannot be found

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng CLI unavailable because dependencies are not installed and npm install is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccffecc6748326a398ab942bac16e3