### PR TITLE
Add ApiService HTTP request unit test

### DIFF
--- a/src/app/api/api.service.spec.ts
+++ b/src/app/api/api.service.spec.ts
@@ -1,16 +1,43 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { ApiService } from './api.service';
 
 describe('ApiService', () => {
   let service: ApiService;
+  let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
     service = TestBed.inject(ApiService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTestingController.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('should call addTransportTypeFn with POST request to correct URL', () => {
+    const mockType = 'Bus';
+    const mockResponse = { success: true };
+    let actualResponse: any;
+
+    service.addTransportTypeFn(mockType).subscribe(response => {
+      actualResponse = response;
+    });
+
+    const req = httpTestingController.expectOne('http://134.209.90.166:8090/admin/transportType');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ type: mockType });
+
+    req.flush(mockResponse);
+
+    expect(actualResponse).toEqual(mockResponse);
   });
 });


### PR DESCRIPTION
## Summary
- configure the ApiService spec to use HttpClientTestingModule and HttpTestingController
- add a unit test that verifies addTransportTypeFn issues a POST request to the expected endpoint and returns the mocked response

## Testing
- `npm test -- --watch=false` *(fails: ng command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0656b46c8326845f56a4be170c11