### PR TITLE
Store entity ID before exclusion cleanup

### DIFF
--- a/src/app/views/parcaredash/parcaredash.component.ts
+++ b/src/app/views/parcaredash/parcaredash.component.ts
@@ -196,14 +196,18 @@ export class ParcaredashComponent implements OnInit {
     console.log("Unloading Reason : ", this.unloading_reason)
 
     try {
-      const res = await this.apiService.excludeCarFn(this.toExcludeEntity.ID).toPromise();
+      const entityId = this.toExcludeEntity ? this.toExcludeEntity.ID : null;
+      if (!entityId) {
+        throw new Error('Entity ID missing for exclusion');
+      }
+      const res = await this.apiService.excludeCarFn(entityId).toPromise();
       if (res) {
         this.toExcludeEntity = null;
         this.getTableData();
       }
       this.activateLoader = false;
       // Saving Unloading Reason ;
-      this.apiService.postUnloadingReason(this.toExcludeEntity.ID, this.unloading_reason).subscribe(
+      this.apiService.postUnloadingReason(entityId, this.unloading_reason).subscribe(
         (res) => {
           console.log("Reason Save Successfully !")
         }


### PR DESCRIPTION
## Summary
- capture the entity ID before resetting the exclusion state so that follow-up API calls have access to it
- ensure the exclusion flow throws if the ID is missing and reuse the stored ID when posting the unloading reason

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd0653695c8326b447aecd8d1899f8